### PR TITLE
Removed bitOrder so that the schema works with existing software

### DIFF
--- a/schemas/pcap.dfdl.xsd
+++ b/schemas/pcap.dfdl.xsd
@@ -44,7 +44,7 @@ Change History
 This DFDL schema provides a DFDL model for PCAP v2.4 binary data, which
 contains network packet capture data.
 
-The message root is 'pcap'.
+The message root is 'PCAP'.
 -->
 
 
@@ -90,7 +90,7 @@ The message root is 'pcap'.
         textStringJustification="left" textStringPadCharacter="%SP;"
         textTrimKind="none" textZonedSignStyle="asciiStandard" trailingSkip="0"
         truncateSpecifiedLengthString="no" useNilForDefault="no" utf16Width="fixed"
-        bitOrder="mostSignificantBitFirst"/>
+        />
       </dfdl:defineFormat>
 
       <dfdl:format ref="pcap:defaults" byteOrder="{ $pcap:ByteOrder }" />


### PR DESCRIPTION
The bitOrder attribute is being discussed by the Working Group, but
is not part of the standard yet.
Also fixed the name of the root element in the comments.
Tested the resulting schema using Daffodil version 0.13.0 (https://opensource.ncsa.illinois.edu/confluence/display/DFDL/Getting+Daffodil).
