### PR TITLE
Update to use newVariableInstance for InclLen, IPSrcGrp, and IPDestGrp

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -7,7 +7,7 @@ version := "0.0.2"
 scalaVersion := "2.12.11"
 
 libraryDependencies ++= Seq(
-  "org.apache.daffodil" %% "daffodil-tdml-processor" % "2.6.0" % "test",
+  "org.apache.daffodil" %% "daffodil-tdml-processor" % "3.1.0-SNAPSHOT" % "test",
   "com.novocode" % "junit-interface" % "0.11" % "test",
   "junit" % "junit" % "4.12" % "test",
 )

--- a/src/main/resources/com/tresys/pcap/xsd/pcap.dfdl.xsd
+++ b/src/main/resources/com/tresys/pcap/xsd/pcap.dfdl.xsd
@@ -99,6 +99,11 @@ The message root is 'PCAP'.
       <dfdl:format ref="pcap:defaults" byteOrder="{ $pcap:ByteOrder }" />
 
       <!--
+        Used to eliminate common subexpression in outputValueCalc of InclLen
+        -->
+      <dfdl:defineVariable name="valueLen" type="xs:int" dfdlx:direction="unparseOnly"/>
+
+      <!--
         used for unparsing when breaking up the parts of an IP address string 1.2.3.4 separated by dots.
         It starts as 1.2.3.4
         Then 2.3.4
@@ -197,10 +202,22 @@ The message root is 'PCAP'.
               <xs:element name="PacketHeader">
                 <xs:complexType>
                   <xs:sequence>
+                    <xs:annotation>
+                      <xs:appinfo source="http://www.ogf.org/dfdl/">
+                        <!--
+                        Common subexpression for valueLength call factored out using NVI.
+                        Note that this is at unparse time, as it is referenced only from
+                        dfdl:outputValueCalc, and note that it is a forward reference into
+                        a "later" part of the infoset.
+                        -->
+                        <dfdl:newVariableInstance ref="pcap:valueLen"
+                          defaultValue="{ dfdl:valueLength(../pcap:LinkLayer, 'bytes') }" />
+                      </xs:appinfo>
+                    </xs:annotation>
                     <xs:element name="Seconds" type="pcap:uint32"/> <!-- TODO: ts_sec should be a dateTime -->
                     <xs:element name="USeconds" type="pcap:uint32"/>
                     <xs:element name="InclLen" type="pcap:uint32" 
-                       dfdl:outputValueCalc="{ if (dfdl:valueLength(../../pcap:LinkLayer, 'bytes') le 60) then 60 else dfdl:valueLength(../../pcap:LinkLayer, 'bytes') }"/>
+                       dfdl:outputValueCalc="{ if ($pcap:valueLen le 60) then 60 else $pcap:valueLen }"/>
                     <xs:element name="OrigLen" type="pcap:uint32" 
                        dfdl:outputValueCalc="{ ../InclLen }"/>
                   </xs:sequence>
@@ -303,7 +320,7 @@ The message root is 'PCAP'.
  <xs:group name="IPAddressGroup">
       <xs:annotation><xs:documentation><![CDATA[
    
-      This grooup is a reusable subroutine of DFDL. It parses a string like 1.2.3.4 into 4 integers named Byte1, Byte2, Byte3, Byte4
+      This group is a reusable subroutine of DFDL. It parses a string like 1.2.3.4 into 4 integers named Byte1, Byte2, Byte3, Byte4
       containing the "." separated integers. 
       
       This is used to unparse IP addresses expressed in the dotted notation that is common. 

--- a/src/main/resources/com/tresys/pcap/xsd/pcap.dfdl.xsd
+++ b/src/main/resources/com/tresys/pcap/xsd/pcap.dfdl.xsd
@@ -52,6 +52,7 @@ The message root is 'PCAP'.
            xmlns:dfdl="http://www.ogf.org/dfdl/dfdl-1.0/"
            xmlns:fn="http://www.w3.org/2005/xpath-functions"
            xmlns:daf="urn:ogf:dfdl:2013:imp:daffodil.apache.org:2018:ext"
+           xmlns:dfdlx="http://www.ogf.org/dfdl/dfdl-1.0/extensions"
            xmlns:pcap="urn:pcap:2.4"
            targetNamespace="urn:pcap:2.4">
 
@@ -96,6 +97,21 @@ The message root is 'PCAP'.
       </dfdl:defineFormat>
 
       <dfdl:format ref="pcap:defaults" byteOrder="{ $pcap:ByteOrder }" />
+
+      <!--
+        used for unparsing when breaking up the parts of an IP address string 1.2.3.4 separated by dots.
+        It starts as 1.2.3.4
+        Then 2.3.4
+        Then 3.4
+        Then 4
+      -->
+
+      <!-- Internally used by ipAddressGroup -->
+      <dfdl:defineVariable name="remainingDottedAddr" type="xs:string" dfdlx:direction="unparseOnly"/>
+      <dfdl:defineVariable name="priorRemainingDottedAddr" type="xs:string" dfdlx:direction="unparseOnly"/>
+
+      <!-- Parameter for ipAddressGroup -->
+      <dfdl:defineVariable name="ipAddressElement" type="xs:string" dfdlx:direction="unparseOnly"/>
 
     </xs:appinfo>
   </xs:annotation>
@@ -256,85 +272,82 @@ The message root is 'PCAP'.
     </xs:complexType>
   </xs:element>
 
-  <xs:simpleType name="IPSeg" dfdl:lengthKind="explicit" dfdl:lengthUnits="bytes" dfdl:length="1">
-    <xs:restriction base="xs:unsignedInt"/>
-  </xs:simpleType>
-
-  <xs:group name="IPSrcGrp">
-    <xs:sequence>
-             <!-- VERY PAINFUL.
-      Until we have dfdl:newVariableInstance, we can't share subexpressions we need here.
-      
-      Even once we do have variables, they will need to be evaluated in a manner that accepts 
-      forward references. Though one might trick it by having a outputValueCalc that forces us
-      to wait until the future item is in the infoset, and then the setVariables will just work because
-      the forward-thing they want is already present in the infoset.
-      
-      But in general I believe variable expression evaluation must be done in a forward-reference-tolerant
-      way when unparsing.
-      
-      Really what we need is variables in DPath/XPath itself so you can write one big 
-      expression, but share subexpressions within - and not have to resort to things
-      outside DPath/XPath just to share an expression. XQuery has this I believe. Where you can 
-      write {{{
-      let $x = /a/b/c
-      return fn:concat($x, $x)
-      }}}
-      We badly need this in DPath. 
-      Then all of the below could just become much cleaner, with no repetition of anything.
-       -->
-        <xs:element name="IPSrcByte1" type="xs:unsignedByte" dfdl:outputValueCalc="{ 
-         xs:unsignedByte(fn:substring-before(../IPSrc, '.'))
-         }"/>
-        <xs:element name="IPSrcByte2" type="xs:unsignedByte" dfdl:outputValueCalc="{
-         xs:unsignedByte(fn:substring-before(fn:substring-after(../IPSrc, '.'), '.'))
-         }"/>
-        <xs:element name="IPSrcByte3" type="xs:unsignedByte" dfdl:outputValueCalc="{
-         xs:unsignedByte(fn:substring-before(fn:substring-after(fn:substring-after(../IPSrc, '.'), '.'), '.'))
-         }"/>
-        <xs:element name="IPSrcByte4" type="xs:unsignedByte" dfdl:outputValueCalc="{
-         xs:unsignedByte(fn:substring-after(fn:substring-after(fn:substring-after(../IPSrc, '.'), '.'), '.'))
-         }"/>
-    </xs:sequence>
+ <xs:group name="IPSrcGrp">
+      <xs:sequence>
+        <xs:annotation><xs:appinfo source="http://www.ogf.org/dfdl/">
+          <dfdl:newVariableInstance ref="pcap:ipAddressElement" defaultValue='{ IPSrc }'/><!-- example 1.2.3.4 -->
+        </xs:appinfo></xs:annotation>
+        <xs:element name="IPSrcString">
+          <xs:complexType>
+            <xs:group ref="pcap:IPAddressGroup"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
   </xs:group>
 
+
   <xs:group name="IPDestGrp">
+      <xs:sequence>
+        <xs:annotation><xs:appinfo source="http://www.ogf.org/dfdl/">
+          <dfdl:newVariableInstance ref="pcap:ipAddressElement" defaultValue='{ IPDest }'/><!-- example 1.2.3.4 -->
+        </xs:appinfo></xs:annotation>
+        <xs:element name="IPDestString">
+          <xs:complexType>
+            <xs:group ref="pcap:IPAddressGroup"/>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+  </xs:group>
+
+
+ <xs:group name="IPAddressGroup">
+      <xs:annotation><xs:documentation><![CDATA[
+   
+      This grooup is a reusable subroutine of DFDL. It parses a string like 1.2.3.4 into 4 integers named Byte1, Byte2, Byte3, Byte4
+      containing the "." separated integers. 
+      
+      This is used to unparse IP addresses expressed in the dotted notation that is common. 
+
+      There is one parameter. Users must bind the $pcap:ipAddressElement variable to the string to be so parsed. 
+
+      ]]></xs:documentation></xs:annotation>
     <xs:sequence>
- <!-- VERY PAINFUL.
-      See comment in IPDestGrp.
-      
-      Also, its a shame we have to have both IPSrcGrp and IPDestGrp that are completely
-      redundant, but we do because they refer up and outward to ../IPSrc and ../IPDest 
-      respectively. 
-      
-      There is no way to parameterize this. 
-      
-      Variables won't work because these are forward references.
-      
-      If variables were evaluated with forward referencing, then this would work
-      but we would need newVariableInstance. The backpath to ../IPDest below would be replaced
-      by $IPAddr, which would be a newVariableInstance for each use of this group.
-      For the IPSrc, it would be setVariable set to ../IPSrc. For the IPDest, it would be (a different instance)
-      set to ../IPDest.
-      
-      So the priority of newVariableInstance, and a clarification to DFDL that variables are
-      evaluated forward-referencing when unparsing is needed.
-      
-      That and we should propose Let-Return expressions as part of the DFDL expression language also.
-      
-       -->
-       <xs:element name="IPDestByte1" type="xs:unsignedByte" dfdl:outputValueCalc="{ 
-         xs:unsignedByte(fn:substring-before(../IPDest, '.'))
-         }"/>
-        <xs:element name="IPDestByte2" type="xs:unsignedByte" dfdl:outputValueCalc="{
-         xs:unsignedByte(fn:substring-before(fn:substring-after(../IPDest, '.'), '.'))
-         }"/>
-        <xs:element name="IPDestByte3" type="xs:unsignedByte" dfdl:outputValueCalc="{
-         xs:unsignedByte(fn:substring-before(fn:substring-after(fn:substring-after(../IPDest, '.'), '.'), '.'))
-         }"/>
-        <xs:element name="IPDestByte4" type="xs:unsignedByte" dfdl:outputValueCalc="{
-         xs:unsignedByte(fn:substring-after(fn:substring-after(fn:substring-after(../IPDest, '.'), '.'), '.'))
-         }"/>
+      <xs:sequence>
+        <xs:annotation><xs:appinfo source="http://www.ogf.org/dfdl/">
+          <dfdl:newVariableInstance ref="pcap:priorRemainingDottedAddr" defaultValue='{ $pcap:ipAddressElement }'/><!-- example 1.2.3.4 -->
+          <dfdl:newVariableInstance ref="pcap:remainingDottedAddr" defaultValue='{ $pcap:priorRemainingDottedAddr }'/><!-- example 1.2.3.4 -->
+        </xs:appinfo></xs:annotation>
+        <xs:element name="Byte1" type="xs:unsignedByte" dfdl:outputValueCalc="{
+          xs:unsignedByte(fn:substring-before($pcap:remainingDottedAddr, '.'))
+          }"/>
+        <xs:sequence>
+          <xs:annotation><xs:appinfo source="http://www.ogf.org/dfdl/">
+            <dfdl:newVariableInstance ref="pcap:priorRemainingDottedAddr" defaultValue='{ $pcap:remainingDottedAddr }'/><!-- example 1.2.3.4 -->
+            <dfdl:newVariableInstance ref="pcap:remainingDottedAddr" defaultValue='{ fn:substring-after($pcap:priorRemainingDottedAddr, ".") }'/><!-- example 2.3.4 -->
+          </xs:appinfo></xs:annotation>
+          <xs:element name="Byte2" type="xs:unsignedByte" dfdl:outputValueCalc="{
+           xs:unsignedByte(fn:substring-before($pcap:remainingDottedAddr, '.'))
+           }"/>
+          <xs:sequence>
+            <xs:annotation><xs:appinfo source="http://www.ogf.org/dfdl/">
+              <dfdl:newVariableInstance ref="pcap:priorRemainingDottedAddr" defaultValue='{ $pcap:remainingDottedAddr }'/><!-- example 2.3.4 -->
+              <dfdl:newVariableInstance ref="pcap:remainingDottedAddr" defaultValue='{ fn:substring-after($pcap:priorRemainingDottedAddr, ".") }'/><!-- example 3.4 -->
+            </xs:appinfo></xs:annotation>
+            <xs:element name="Byte3" type="xs:unsignedByte" dfdl:outputValueCalc="{
+              xs:unsignedByte(fn:substring-before($pcap:remainingDottedAddr, '.'))
+              }"/>
+            <xs:sequence>
+              <xs:annotation><xs:appinfo source="http://www.ogf.org/dfdl/">
+                <dfdl:newVariableInstance ref="pcap:priorRemainingDottedAddr" defaultValue='{ $pcap:remainingDottedAddr }'/><!-- example 3.4 -->
+                <dfdl:newVariableInstance ref="pcap:remainingDottedAddr" defaultValue='{ fn:substring-after($pcap:priorRemainingDottedAddr, ".") }'/><!-- example 4 -->
+              </xs:appinfo></xs:annotation>
+              <xs:element name="Byte4" type="xs:unsignedByte" dfdl:outputValueCalc="{
+                xs:unsignedByte($pcap:remainingDottedAddr)
+                }"/>
+            </xs:sequence>
+          </xs:sequence>
+        </xs:sequence>
+      </xs:sequence>
     </xs:sequence>
   </xs:group>
 
@@ -373,9 +386,9 @@ The message root is 'PCAP'.
                 else -1 }"/>
               <xs:element name="Checksum" type="pcap:bit" dfdl:length="16" />
               <xs:sequence dfdl:hiddenGroupRef="pcap:IPSrcGrp"/>
-              <xs:element name="IPSrc" type="xs:string" dfdl:inputValueCalc="{ fn:concat(../IPSrcByte1, '.', ../IPSrcByte2, '.', ../IPSrcByte3, '.', ../IPSrcByte4) }"/>
+              <xs:element name="IPSrc" type="xs:string" dfdl:inputValueCalc="{ fn:concat(../IPSrcString/Byte1, '.', ../IPSrcString/Byte2, '.', ../IPSrcString/Byte3, '.', ../IPSrcString/Byte4) }"/>
               <xs:sequence dfdl:hiddenGroupRef="pcap:IPDestGrp"/>
-              <xs:element name="IPDest" type="xs:string" dfdl:inputValueCalc="{ fn:concat(../IPDestByte1, '.', ../IPDestByte2, '.', ../IPDestByte3, '.', ../IPDestByte4) }"/>
+              <xs:element name="IPDest" type="xs:string" dfdl:inputValueCalc="{ fn:concat(../IPDestString/Byte1, '.', ../IPDestString/Byte2, '.', ../IPDestString/Byte3, '.', ../IPDestString/Byte4) }"/>
             </xs:sequence>
           </xs:complexType>
         </xs:element>


### PR DESCRIPTION
https://github.com/DFDLSchemas/PCAP/issues/9

This update shows that dfdl:newVariableInstance requires a specific enhancement to specify the direction (parse, unparse, both) when it is to be evaluated. Because in the usage here, it is *only* sensible to evaluate it at unparse time. Not at parse time. 